### PR TITLE
Fix JVM target mismatch

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -21,6 +21,15 @@ android {
             minifyEnabled false
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
- set Java 8 as the target for the Android wrapper project

## Testing
- `./gradlew tasks`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68410d370e488326b7e1d879d294d5ac