### PR TITLE
Fix JVM target mismatch

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -4,14 +4,14 @@ plugins {
 }
 
 android {
-    compileSdk 33
+    compileSdk 36
 
     namespace "com.example.passwordmanager"
 
     defaultConfig {
         applicationId "com.example.passwordmanager"
         minSdk 24
-        targetSdk 33
+        targetSdk 36
         versionCode 1
         versionName "1.0"
     }
@@ -20,6 +20,15 @@ android {
         release {
             minifyEnabled false
         }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
     }
 }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,9 @@
     <application
         android:label="PasswordManager"
         android:theme="@style/Theme.AppCompat.Light.NoActionBar">
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
## Summary
- set Java 8 as the target for the Android wrapper project
- bump compileSdk and targetSdk to 36

## Testing
- `./android/gradlew -p android tasks --all`
- `./android/gradlew -p android assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68410d370e488326b7e1d879d294d5ac