### PR TITLE
Enhance Android UI and biometrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ or run the GitHub Actions workflow manually to build the APK automatically. The
 generated file is attached to the release so you can install it on your device
 without setting up Android Studio.
 
+### **Improved Android Experience**
+The Android app now includes a native bottom navigation bar and Material styling for better responsiveness. Stored data is decrypted using a hardware-backed key that requires your fingerprint or device PIN each time.
+
 ---
 
 ## **Potential Risks & Considerations**

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -36,4 +36,7 @@ dependencies {
     implementation "androidx.core:core-ktx:1.12.0"
     implementation "androidx.appcompat:appcompat:1.6.1"
     implementation "androidx.biometric:biometric:1.2.0-alpha05"
+    implementation "com.google.android.material:material:1.11.0"
+    implementation "androidx.fragment:fragment-ktx:1.7.1"
+    implementation "androidx.security:security-crypto:1.1.0-alpha06"
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,9 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.passwordmanager">
 
+    <uses-permission android:name="android.permission.USE_BIOMETRIC" />
+
     <application
         android:label="PasswordManager"
-        android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+        android:theme="@style/Theme.PasswordManager">
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/android/app/src/main/java/com/example/passwordmanager/MainActivity.kt
+++ b/android/app/src/main/java/com/example/passwordmanager/MainActivity.kt
@@ -2,59 +2,39 @@ package com.example.passwordmanager
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.biometric.BiometricPrompt
-import androidx.biometric.BiometricManager
-import androidx.core.content.ContextCompat
-import android.webkit.WebView
-import android.webkit.WebViewClient
+import androidx.appcompat.widget.Toolbar
+import androidx.fragment.app.Fragment
+import com.google.android.material.bottomnavigation.BottomNavigationView
 
 class MainActivity : AppCompatActivity() {
-    private lateinit var webView: WebView
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        webView = WebView(this)
-        webView.settings.javaScriptEnabled = true
-        webView.settings.domStorageEnabled = true
-        webView.settings.allowFileAccess = true
-        webView.webViewClient = WebViewClient()
-        setContentView(webView)
+        setContentView(R.layout.activity_main)
 
-        authenticateAndLoad()
-    }
+        val toolbar: Toolbar = findViewById(R.id.toolbar)
+        setSupportActionBar(toolbar)
 
-    private fun authenticateAndLoad() {
-        val biometricManager = BiometricManager.from(this)
-        val canAuth = biometricManager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG)
+        loadFragment(WebViewFragment())
 
-        if (canAuth == BiometricManager.BIOMETRIC_SUCCESS) {
-            val executor = ContextCompat.getMainExecutor(this)
-            val biometricPrompt = BiometricPrompt(this, executor,
-                object : BiometricPrompt.AuthenticationCallback() {
-                    override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
-                        super.onAuthenticationSucceeded(result)
-                        loadWebApp()
-                    }
-
-                    override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
-                        super.onAuthenticationError(errorCode, errString)
-                        loadWebApp()
-                    }
-                })
-
-            val promptInfo = BiometricPrompt.PromptInfo.Builder()
-                .setTitle("Unlock")
-                .setSubtitle("Authenticate to decrypt your private key")
-                .setNegativeButtonText("Cancel")
-                .build()
-
-            biometricPrompt.authenticate(promptInfo)
-        } else {
-            loadWebApp()
+        val bottomNav: BottomNavigationView = findViewById(R.id.bottom_nav)
+        bottomNav.setOnItemSelectedListener { item ->
+            when (item.itemId) {
+                R.id.nav_home -> {
+                    loadFragment(WebViewFragment())
+                    true
+                }
+                R.id.nav_settings -> {
+                    loadFragment(SettingsFragment())
+                    true
+                }
+                else -> false
+            }
         }
     }
 
-    private fun loadWebApp() {
-        webView.loadUrl("file:///android_asset/www/index.html")
+    private fun loadFragment(fragment: Fragment) {
+        supportFragmentManager.beginTransaction()
+            .replace(R.id.fragment_container, fragment)
+            .commit()
     }
 }

--- a/android/app/src/main/java/com/example/passwordmanager/SecureStorage.kt
+++ b/android/app/src/main/java/com/example/passwordmanager/SecureStorage.kt
@@ -1,0 +1,33 @@
+package com.example.passwordmanager
+
+import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+
+object SecureStorage {
+    private const val PREF_FILE = "secure_data"
+    private const val KEY_DATA = "encrypted_json"
+
+    private fun prefs(context: Context) = EncryptedSharedPreferences.create(
+        context,
+        PREF_FILE,
+        masterKey(context),
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
+
+    private fun masterKey(context: Context): MasterKey {
+        return MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .setUserAuthenticationRequired(true, 0)
+            .build()
+    }
+
+    fun save(context: Context, data: String) {
+        prefs(context).edit().putString(KEY_DATA, data).apply()
+    }
+
+    fun load(context: Context): String? {
+        return prefs(context).getString(KEY_DATA, null)
+    }
+}

--- a/android/app/src/main/java/com/example/passwordmanager/SettingsFragment.kt
+++ b/android/app/src/main/java/com/example/passwordmanager/SettingsFragment.kt
@@ -1,0 +1,17 @@
+package com.example.passwordmanager
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+
+class SettingsFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return inflater.inflate(R.layout.fragment_settings, container, false)
+    }
+}

--- a/android/app/src/main/java/com/example/passwordmanager/WebAppInterface.kt
+++ b/android/app/src/main/java/com/example/passwordmanager/WebAppInterface.kt
@@ -1,0 +1,16 @@
+package com.example.passwordmanager
+
+import android.content.Context
+import android.webkit.JavascriptInterface
+
+class WebAppInterface(private val context: Context) {
+    @JavascriptInterface
+    fun saveEncryptedData(data: String) {
+        SecureStorage.save(context, data)
+    }
+
+    @JavascriptInterface
+    fun loadEncryptedData(): String? {
+        return SecureStorage.load(context)
+    }
+}

--- a/android/app/src/main/java/com/example/passwordmanager/WebViewFragment.kt
+++ b/android/app/src/main/java/com/example/passwordmanager/WebViewFragment.kt
@@ -1,0 +1,79 @@
+package com.example.passwordmanager
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricPrompt
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
+
+/** Interface providing secure storage methods to the WebView */
+import com.example.passwordmanager.WebAppInterface
+
+class WebViewFragment : Fragment() {
+    private lateinit var webView: WebView
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return inflater.inflate(R.layout.fragment_webview, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        webView = view.findViewById(R.id.webview)
+        webView.settings.javaScriptEnabled = true
+        webView.settings.domStorageEnabled = true
+        webView.settings.allowFileAccess = true
+        webView.webViewClient = WebViewClient()
+        authenticateAndLoad()
+    }
+
+    private fun authenticateAndLoad() {
+        val biometricManager = BiometricManager.from(requireContext())
+        val canAuth = biometricManager.canAuthenticate(
+            BiometricManager.Authenticators.BIOMETRIC_STRONG or
+                    BiometricManager.Authenticators.DEVICE_CREDENTIAL
+        )
+
+        if (canAuth == BiometricManager.BIOMETRIC_SUCCESS) {
+            val executor = ContextCompat.getMainExecutor(requireContext())
+            val biometricPrompt = BiometricPrompt(this, executor,
+                object : BiometricPrompt.AuthenticationCallback() {
+                    override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                        super.onAuthenticationSucceeded(result)
+                        webView.addJavascriptInterface(WebAppInterface(requireContext()), "Android")
+                        loadWebApp()
+                    }
+
+                    override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+                        super.onAuthenticationError(errorCode, errString)
+                        loadWebApp()
+                    }
+                })
+
+            val promptInfo = BiometricPrompt.PromptInfo.Builder()
+                .setTitle("Unlock")
+                .setSubtitle("Authenticate to decrypt your data")
+                .setAllowedAuthenticators(
+                    BiometricManager.Authenticators.BIOMETRIC_STRONG or
+                            BiometricManager.Authenticators.DEVICE_CREDENTIAL
+                )
+                .build()
+
+            biometricPrompt.authenticate(promptInfo)
+        } else {
+            loadWebApp()
+        }
+    }
+
+    private fun loadWebApp() {
+        webView.loadUrl("file:///android_asset/www/index.html")
+    }
+}

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:theme="?attr/actionBarTheme" />
+
+    <FrameLayout
+        android:id="@+id/fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bottom_nav"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:menu="@menu/bottom_nav_menu" />
+</LinearLayout>

--- a/android/app/src/main/res/layout/fragment_settings.xml
+++ b/android/app/src/main/res/layout/fragment_settings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <TextView
+        android:id="@+id/settings_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="Settings go here"
+        android:textSize="18sp" />
+</ScrollView>

--- a/android/app/src/main/res/layout/fragment_webview.xml
+++ b/android/app/src/main/res/layout/fragment_webview.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WebView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/webview"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/android/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/android/app/src/main/res/menu/bottom_nav_menu.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/nav_home"
+        android:icon="@android:drawable/ic_menu_view"
+        android:title="@string/home" />
+    <item
+        android:id="@+id/nav_settings"
+        android:icon="@android:drawable/ic_menu_manage"
+        android:title="@string/settings" />
+</menu>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="purple_500">#6200EE</color>
+    <color name="purple_700">#3700B3</color>
+    <color name="teal_200">#03DAC5</color>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">PasswordManager</string>
+    <string name="home">Home</string>
+    <string name="settings">Settings</string>
+</resources>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.PasswordManager" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <!-- Customize your theme here -->
+    </style>
+</resources>


### PR DESCRIPTION
## Summary
- overhaul Android UI using toolbar and bottom navigation
- add fragments to host the WebView and a placeholder settings screen
- fallback to device PIN when authenticating with BiometricPrompt
- store encrypted data with a hardware-backed key via EncryptedSharedPreferences
- expose Android storage through a WebView JavaScript interface
- style app with Material Components and document the Android experience

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68411c91f12c83268dd78e442d4189e8