### PR TITLE
Enable restore from specific Nostr event ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,4 +138,5 @@ Explore the full source code on GitHub: [GitHub Repository](https://github.com/f
 - from the private key, derivate a nostr nsec and npub that will be used to sign and broadcast events to nostr relays
 - By Pressing the button the user puashes its nonces dictionary in a dictionary encrypted by the private key, then it will be signed by the same private key and broadcasted to nostr relays.
 - When the user wants to restore its nostr relays nonces backup and status, the latest event broadcasted by that npub gets pulled and decrypted with the main private key
+- A dedicated history screen lists previous backups; touching one restores that specific event ID. You can also paste an event ID manually to restore.
 - There has to be in the ui another option to edit the nonces values and push them again to edit if wrong.

--- a/index.html
+++ b/index.html
@@ -379,6 +379,9 @@
     <button class="option-btn" onclick="restoreFromNostr()">
         Restore Backup from Nostr
     </button>
+    <button class="option-btn" onclick="showScreen('restoreNostrIdScreen')">
+        Restore Using Event ID
+    </button>
     <button class="option-btn" onclick="openNostrHistory()">
         Nostr Backup History
     </button>
@@ -427,6 +430,24 @@
     <textarea class="input-field" id="noncesEditor" rows="10"></textarea>
     <button class="option-btn" onclick="saveEditedNonces()">Save Nonces</button>
     <button class="back-btn" onclick="navigateBack('editNoncesScreen')">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+        </svg>
+        Back
+    </button>
+</div>
+
+<!-- Restore From Event ID Screen -->
+<div class="screen hidden" id="restoreNostrIdScreen">
+    <h2 class="title">Restore via Event ID</h2>
+    <div class="input-group">
+        <label class="input-label" for="nostrEventIdField">Event ID</label>
+        <input type="text" class="input-field" id="nostrEventIdField">
+    </div>
+    <button class="option-btn" onclick="const id=document.getElementById('nostrEventIdField').value.trim(); if(id){restoreFromNostrId(id);} else { alert('Enter an Event ID'); }">
+        Restore Backup
+    </button>
+    <button class="back-btn" onclick="navigateBack('restoreNostrIdScreen')">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
         </svg>


### PR DESCRIPTION
## Summary
- add button to restore using a manual Nostr event ID
- new screen to input the event ID and trigger `restoreFromNostrId`
- document manual restore option in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68855f80d3b083269336af9612273952