### PR TITLE
feat: add nonce export option

### DIFF
--- a/index.html
+++ b/index.html
@@ -440,6 +440,7 @@
     <h2 class="title">Edit Nonces</h2>
     <textarea class="input-field" id="noncesEditor" rows="10"></textarea>
     <button class="option-btn" onclick="saveEditedNonces()">Save Nonces</button>
+    <button class="option-btn" onclick="downloadNoncesJson()">Download Nonces JSON</button>
     <button class="back-btn" onclick="navigateBack('editNoncesScreen')">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />

--- a/indexV32.html
+++ b/indexV32.html
@@ -440,6 +440,7 @@
     <h2 class="title">Edit Nonces</h2>
     <textarea class="input-field" id="noncesEditor" rows="10"></textarea>
     <button class="option-btn" onclick="saveEditedNonces()">Save Nonces</button>
+    <button class="option-btn" onclick="downloadNoncesJson()">Download Nonces JSON</button>
     <button class="back-btn" onclick="navigateBack('editNoncesScreen')">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />

--- a/script.js
+++ b/script.js
@@ -574,6 +574,19 @@ function saveEditedNonces() {
     }
 }
 
+function downloadNoncesJson() {
+    const data = localStoredData['users'] || {};
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'nonces.json';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+}
+
 window.backupToNostr = async function () {
     const { nip04, relayInit, getEventHash, signEvent, getPublicKey } = window.NostrTools;
 

--- a/scriptV32.js
+++ b/scriptV32.js
@@ -574,6 +574,19 @@ function saveEditedNonces() {
     }
 }
 
+function downloadNoncesJson() {
+    const data = localStoredData['users'] || {};
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'nonces.json';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+}
+
 window.backupToNostr = async function () {
     const { nip04, relayInit, getEventHash, signEvent, getPublicKey } = window.NostrTools;
 


### PR DESCRIPTION
## Summary
- allow users to download nonces as plain JSON
- add export control to nonce editors in both UI versions

## Testing
- `npm test` (fails: ENOENT: no package.json)


------
https://chatgpt.com/codex/tasks/task_e_68adc14bb84c833394d0996f4e556393