### PR TITLE
Implement Nostr key derivation and encryption

### DIFF
--- a/python/gui.py
+++ b/python/gui.py
@@ -71,7 +71,7 @@ class PasswordManagerGUI(tk.Tk):
             "nonce": self.nonce_entry.get().strip(),
             "password": self.password_var.get(),
         }
-        event_id = backup_to_nostr(self.keys["private_key"], data)
+        event_id = backup_to_nostr(self.keys["private_key"], data, debug=True)
         messagebox.showinfo("Backup", f"Backup stored with id {event_id}")
 
     def restore(self):
@@ -79,7 +79,7 @@ class PasswordManagerGUI(tk.Tk):
             messagebox.showerror("Error", "Verify the seed first")
             return
         try:
-            data = restore_from_nostr(self.keys["private_key"])
+            data = restore_from_nostr(self.keys["private_key"], debug=True)
         except Exception as exc:
             messagebox.showerror("Restore", str(exc))
             return

--- a/python/password_manager/nostr_utils.py
+++ b/python/password_manager/nostr_utils.py
@@ -1,43 +1,239 @@
+"""Helpers for backing up and restoring data via the Nostr protocol.
+
+The real Nostr network requires WebSocket connectivity and Schnorr
+signatures.  The execution environment for the educational version of this
+project does not have those third‑party dependencies available, so the
+implementation below performs the cryptography locally while still creating
+properly structured Nostr events.  Key derivation and encryption follow the
+same rules as the accompanying web application so the two remain compatible.
+Extensive debug logging is provided to mirror what a full implementation
+would do.
+"""
+
+import base64
 import json
 import hashlib
+import logging
+import os
 import time
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List, Optional
+
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives import hashes, padding
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+
+logger = logging.getLogger(__name__)
+
 
 # File used to store simulated Nostr backup events
 BACKUP_FILE = Path(__file__).resolve().parent / "nostr_backups.json"
 
+# Order of the secp256k1 curve used for Schnorr signing
+SECP256K1_N = int(
+    "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141", 16
+)
 
-def backup_to_nostr(private_key_hex: str, data: Dict) -> str:
-    """Simulate backing up data to Nostr by writing to a local JSON file.
 
-    Returns the event id that can later be used for restoration."""
-    content = json.dumps(data, sort_keys=True)
-    event_id = hashlib.sha256(content.encode()).hexdigest()
-    pubkey = hashlib.sha256(private_key_hex.encode()).hexdigest()
-    event = {
+def _tagged_hash(tag: str, msg: bytes) -> bytes:
+    """Return ``sha256(sha256(tag) || sha256(tag) || msg)`` as described in BIP‑340."""
+    tag_hash = hashlib.sha256(tag.encode()).digest()
+    return hashlib.sha256(tag_hash + tag_hash + msg).digest()
+
+
+def _schnorr_sign(sk_hex: str, msg32: bytes) -> str:
+    """Create a BIP‑340 Schnorr signature for ``msg32`` using ``sk_hex``."""
+    d = int(sk_hex, 16)
+    if not (1 <= d < SECP256K1_N):
+        raise ValueError("Invalid private key")
+
+    priv = ec.derive_private_key(d, ec.SECP256K1())
+    pub_numbers = priv.public_key().public_numbers()
+    if pub_numbers.y % 2:
+        d = SECP256K1_N - d
+        priv = ec.derive_private_key(d, ec.SECP256K1())
+        pub_numbers = priv.public_key().public_numbers()
+
+    aux = os.urandom(32)
+    t = d ^ int.from_bytes(_tagged_hash("BIP0340/aux", aux), "big")
+    k0 = int.from_bytes(
+        _tagged_hash(
+            "BIP0340/nonce",
+            t.to_bytes(32, "big") + pub_numbers.x.to_bytes(32, "big") + msg32,
+        ),
+        "big",
+    ) % SECP256K1_N
+    if k0 == 0:
+        raise ValueError("Failure. This happens only with negligible probability.")
+
+    R = ec.derive_private_key(k0, ec.SECP256K1()).public_key().public_numbers()
+    if R.y % 2:
+        k0 = SECP256K1_N - k0
+        R = ec.derive_private_key(k0, ec.SECP256K1()).public_key().public_numbers()
+
+    e = int.from_bytes(
+        _tagged_hash(
+            "BIP0340/challenge",
+            R.x.to_bytes(32, "big") + pub_numbers.x.to_bytes(32, "big") + msg32,
+        ),
+        "big",
+    ) % SECP256K1_N
+
+    sig = R.x.to_bytes(32, "big") + ((k0 + e * d) % SECP256K1_N).to_bytes(32, "big")
+    return sig.hex()
+
+
+def _derive_keypair(private_key_hex: str) -> (str, str, ec.EllipticCurvePrivateKey):
+    """Derive the Nostr key pair from the web compatible ``private_key_hex``."""
+    logger.debug("Deriving Nostr keys from private key hex")
+    sk_hex = hashlib.sha256(private_key_hex.encode()).hexdigest()
+    priv = ec.derive_private_key(int(sk_hex, 16), ec.SECP256K1())
+    pk_numbers = priv.public_key().public_numbers()
+    pk_hex = f"{pk_numbers.x:064x}"
+    logger.debug("Derived sk=%s, pk=%s", sk_hex, pk_hex)
+    return sk_hex, pk_hex, priv
+
+
+def _encrypt_nip04(priv: ec.EllipticCurvePrivateKey, plaintext: str) -> str:
+    """Encrypt ``plaintext`` using NIP‑04 (self‑encryption)."""
+    logger.debug("Encrypting data via NIP‑04")
+    shared = priv.exchange(ec.ECDH(), priv.public_key())
+    key = hashlib.sha256(shared).digest()
+    iv = os.urandom(16)
+    padder = padding.PKCS7(128).padder()
+    padded = padder.update(plaintext.encode()) + padder.finalize()
+    cipher = Cipher(algorithms.AES(key), modes.CBC(iv))
+    ct = cipher.encryptor().update(padded) + cipher.encryptor().finalize()
+    return f"{base64.b64encode(ct).decode()}?iv={base64.b64encode(iv).decode()}"
+
+
+def _decrypt_nip04(priv: ec.EllipticCurvePrivateKey, ciphertext: str) -> str:
+    """Decrypt a NIP‑04 payload produced by :func:`_encrypt_nip04`."""
+    logger.debug("Decrypting NIP‑04 payload")
+    try:
+        data, iv_b64 = ciphertext.split("?iv=")
+    except ValueError as exc:
+        raise ValueError("Invalid ciphertext format") from exc
+
+    shared = priv.exchange(ec.ECDH(), priv.public_key())
+    key = hashlib.sha256(shared).digest()
+    iv = base64.b64decode(iv_b64)
+    ct = base64.b64decode(data)
+    cipher = Cipher(algorithms.AES(key), modes.CBC(iv))
+    padded = cipher.decryptor().update(ct) + cipher.decryptor().finalize()
+    unpadder = padding.PKCS7(128).unpadder()
+    plaintext = unpadder.update(padded) + unpadder.finalize()
+    return plaintext.decode()
+
+
+def _create_event(sk_hex: str, pk_hex: str, content: str) -> Dict:
+    """Create a Nostr style event signed with ``sk_hex``."""
+    logger.debug("Creating event for content: %s", content)
+    event = [
+        0,
+        pk_hex,
+        int(time.time()),
+        1,
+        [["t", "nostr-pwd-backup"]],
+        content,
+    ]
+    serialized = json.dumps(event, separators=(",", ":"), ensure_ascii=False)
+    event_id = hashlib.sha256(serialized.encode()).hexdigest()
+    sig = _schnorr_sign(sk_hex, bytes.fromhex(event_id))
+    nostr_event = {
         "id": event_id,
-        "pubkey": pubkey,
-        "created_at": int(time.time()),
+        "pubkey": pk_hex,
+        "created_at": event[2],
+        "kind": 1,
+        "tags": [["t", "nostr-pwd-backup"]],
         "content": content,
+        "sig": sig,
     }
+    logger.debug("Created event: %s", nostr_event)
+    return nostr_event
 
+
+def backup_to_nostr(
+    private_key_hex: str,
+    data: Dict,
+    relay_urls: Optional[List[str]] = None,
+    debug: bool = False,
+) -> str:
+    """Backup ``data`` by writing a Nostr style event to a local file.
+
+    Parameters
+    ----------
+    private_key_hex:
+        Hex representation of the user's private key.
+    data:
+        Arbitrary JSON‑serialisable dictionary to back up.
+    relay_urls:
+        Placeholder for real relay URLs.  When ``None`` (the default) the
+        backup is stored locally.
+    debug:
+        When ``True`` debug information is logged using :mod:`logging`.
+
+    Returns
+    -------
+    str
+        The generated event id which can later be used to locate the
+        backup.
+    """
+
+    if debug:
+        logging.basicConfig(level=logging.DEBUG)
+
+    sk_hex, pk_hex, priv = _derive_keypair(private_key_hex)
+    content = _encrypt_nip04(priv, json.dumps(data, sort_keys=True))
+    event = _create_event(sk_hex, pk_hex, content)
+
+    if relay_urls:
+        logger.debug(
+            "Relay URLs provided (%s) but network publishing is not "
+            "implemented in this environment.",
+            relay_urls,
+        )
+
+    # In this educational environment we simply append the event to a JSON
+    # file.  A full implementation would publish the event to the provided
+    # relay URLs using WebSockets.
+    logger.debug("Writing event to %s", BACKUP_FILE)
     backups = []
     if BACKUP_FILE.exists():
         backups = json.loads(BACKUP_FILE.read_text())
     backups.append(event)
     BACKUP_FILE.write_text(json.dumps(backups, indent=2))
-    return event_id
+    return event["id"]
 
 
-def restore_from_nostr(private_key_hex: str) -> Dict:
-    """Restore data for a given private key from the simulated Nostr storage."""
+def restore_from_nostr(
+    private_key_hex: str,
+    relay_urls: Optional[List[str]] = None,
+    debug: bool = False,
+) -> Dict:
+    """Restore backup data for the provided key from the simulated storage."""
+
+    if debug:
+        logging.basicConfig(level=logging.DEBUG)
+
+    if relay_urls:
+        logger.debug(
+            "Relay URLs provided (%s) but network retrieval is not "
+            "implemented in this environment.",
+            relay_urls,
+        )
+
     if not BACKUP_FILE.exists():
         raise FileNotFoundError("No backups available")
 
-    pubkey = hashlib.sha256(private_key_hex.encode()).hexdigest()
+    sk_hex, pk_hex, priv = _derive_keypair(private_key_hex)
+    logger.debug("Looking for events matching pubkey %s", pk_hex)
+
     backups = json.loads(BACKUP_FILE.read_text())
     for event in reversed(backups):
-        if event.get("pubkey") == pubkey:
-            return json.loads(event.get("content", "{}"))
+        if event.get("pubkey") == pk_hex:
+            logger.debug("Found matching event: %s", event)
+            decrypted = _decrypt_nip04(priv, event.get("content", ""))
+            return json.loads(decrypted)
     raise ValueError("No backup found for provided key")

--- a/python/password_manager/seed.py
+++ b/python/password_manager/seed.py
@@ -14,6 +14,7 @@ desktop application match those from the web version.
 from pathlib import Path
 import hashlib
 from typing import Dict, List
+from cryptography.hazmat.primitives.asymmetric import ec
 
 WORDLIST_PATH = Path(__file__).resolve().parents[1] / "static" / "bip39_wordlist.txt"
 with open(WORDLIST_PATH, "r", encoding="utf-8") as f:
@@ -54,7 +55,10 @@ def derive_private_key(seed_phrase: str) -> str:
 
 
 def derive_npub_from_nsec(nsec_hex: str) -> str:
-    return hashlib.sha256(nsec_hex.encode()).hexdigest()
+    """Derive the Nostr public key (hex) from the ``nsec`` secret."""
+    sk = ec.derive_private_key(int(nsec_hex, 16), ec.SECP256K1())
+    pk_numbers = sk.public_key().public_numbers()
+    return f"{pk_numbers.x:064x}"
 
 
 def derive_keys(seed_phrase: str) -> dict:

--- a/python/tests/test_nostr_utils.py
+++ b/python/tests/test_nostr_utils.py
@@ -9,9 +9,13 @@ def test_backup_and_restore(tmp_path, monkeypatch):
     key = "deadbeef"
     data = {"foo": "bar"}
 
-    event_id = backup_to_nostr(key, data)
+    event_id = backup_to_nostr(key, data, debug=True)
     assert temp_file.exists()
     assert isinstance(event_id, str)
 
-    restored = restore_from_nostr(key)
+    # Ensure the stored content is encrypted (not raw JSON)
+    stored = json.loads(temp_file.read_text())[-1]
+    assert stored["content"] != json.dumps(data, sort_keys=True)
+
+    restored = restore_from_nostr(key, debug=True)
     assert restored == data


### PR DESCRIPTION
## Summary
- derive Nostr keypair from seed-based private key, encrypt backups via NIP-04, and sign events with Schnorr
- compute npub from nsec using secp256k1 to match webapp derivation
- verify encrypted backups restore correctly in tests

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aeca680e0c8333a6a33386381d2eab