### PR TITLE
feat: integrate python nostr library

### DIFF
--- a/python/app.py
+++ b/python/app.py
@@ -1,11 +1,35 @@
+"""Application entry point for the desktop password manager."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
 from gui import PasswordManagerGUI
 
 
-def main() -> None:
-    """Launch the Tkinter-based password manager."""
-    app = PasswordManagerGUI()
+def main(debug: bool = False) -> None:
+    """Launch the Tkinter-based password manager.
+
+    Parameters
+    ----------
+    debug:
+        When ``True`` verbose logging is enabled across the application.
+    """
+
+    if debug:
+        logging.basicConfig(level=logging.DEBUG)
+
+    app = PasswordManagerGUI(debug=debug)
     app.mainloop()
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="SecureVault Manager")
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    args = parser.parse_args()
+    main(debug=args.debug)

--- a/python/gui.py
+++ b/python/gui.py
@@ -16,8 +16,9 @@ from password_manager.nostr_utils import (
 
 
 class PasswordManagerGUI(tk.Tk):
-    def __init__(self):
+    def __init__(self, debug: bool = False):
         super().__init__()
+        self.debug = debug
         self.title("SecureVault Manager")
         # Original interface was 400x400 which became cramped as new
         # functionality was added. Increase the height to provide more space
@@ -107,7 +108,7 @@ class PasswordManagerGUI(tk.Tk):
             "password": self.password_var.get(),
         }
         event_id = backup_to_nostr(
-            self.keys["private_key"], data, relay_urls=relay_urls, debug=True
+            self.keys["private_key"], data, relay_urls=relay_urls, debug=self.debug
         )
         messagebox.showinfo("Backup", f"Backup stored with id {event_id}")
 
@@ -118,7 +119,7 @@ class PasswordManagerGUI(tk.Tk):
         relay_urls = [u.strip() for u in self.relay_entry.get().split(',') if u.strip()] or None
         try:
             data = restore_from_nostr(
-                self.keys["private_key"], relay_urls=relay_urls, debug=True
+                self.keys["private_key"], relay_urls=relay_urls, debug=self.debug
             )
         except Exception as exc:
             messagebox.showerror("Restore", str(exc))
@@ -138,7 +139,7 @@ class PasswordManagerGUI(tk.Tk):
             return
         relay_urls = [u.strip() for u in self.relay_entry.get().split(',') if u.strip()] or None
         history = restore_history_from_nostr(
-            self.keys["private_key"], relay_urls=relay_urls, debug=True
+            self.keys["private_key"], relay_urls=relay_urls, debug=self.debug
         )
         win = tk.Toplevel(self)
         win.title("Nostr History")

--- a/python/password_manager/nostr_utils.py
+++ b/python/password_manager/nostr_utils.py
@@ -26,6 +26,8 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives import hashes, padding
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
+from .seed import derive_npub_from_nsec
+
 # ``python-nostr`` provides higher level helpers for creating and signing
 # Nostr events.  The library is optional so the application can still run in
 # restricted environments (such as the execution sandbox used for the
@@ -128,8 +130,7 @@ def _derive_keypair(
     # ``python-nostr`` (when available) is leveraged for convenience methods
     # like event signing and NIP‑04 helpers.
     priv = ec.derive_private_key(int(sk_hex, 16), ec.SECP256K1())
-    pk_numbers = priv.public_key().public_numbers()
-    pk_hex = f"{pk_numbers.x:064x}"
+    pk_hex = derive_npub_from_nsec(sk_hex)
 
     nostr_priv = NostrPrivateKey.from_hex(sk_hex) if NostrPrivateKey else None
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,7 @@
 mnemonic
 cryptography
+# Optional support for interacting with the Nostr protocol.  The application
+# gracefully falls back to a local implementation when this dependency is not
+# available, but including it here allows the full experience when the package
+# can be installed.
+nostr

--- a/python/testing.md
+++ b/python/testing.md
@@ -1,0 +1,63 @@
+# Testing Guidelines
+
+This document outlines suggested strategies for exercising the Python password
+manager implementation.  Automated tests live in `tests/`, but the following
+notes describe additional manual checks and rationale for each module.
+
+## Verify Password Derivation Against the Web Version
+
+1. Launch `index.html` from the project root in a browser.
+2. Enter a master password, username, site name, and counter; record the
+   generated password.
+3. From the same values run the Python generator:
+   ```bash
+   python - <<'PY'
+   from password_manager.password import generate_password
+   print(generate_password("master", "user", "example.com", 1))
+   PY
+   ```
+4. Confirm that the value matches the one produced by the web interface.
+5. Repeat with different inputs to ensure the prefix `PASS`, SHA‑256 digest
+   truncation, and `249+` suffix rules are consistent.
+
+## Seed Phrase Utilities
+
+- **`verify_seed_phrase`** – Provide known valid and invalid BIP‑39 phrases to
+  check wordlist membership and word count boundaries.
+- **`derive_private_key` & `derive_keys`** – Use fixed phrases to ensure the
+  derived private key, `nsec`, and `npub` match expected vectors.  Compare
+  outputs with the web version when available.
+- **`generate_seed_phrase`** – Call with default and alternate strengths
+  (128–256 bits) and verify word count and that `verify_seed_phrase` accepts the
+  result.
+
+## Nostr Backup and Restore
+
+- **`backup_to_nostr`** – Ensure the function writes an encrypted event to the
+  local backup file and returns an event id.  When relay URLs are supplied,
+  verify WebSocket logging and successful publication.
+- **`restore_from_nostr`** – With the backup file present, confirm data is
+  decrypted correctly.  Delete the local file to force fetching from a relay and
+  assert the round‑tripped payload matches the original.
+- **`restore_history_from_nostr`** – Create multiple backups and verify that the
+  returned list reflects chronological ordering and complete history.
+- When the optional `python-nostr` library is installed, repeat the above to
+  ensure event creation and NIP‑04 encryption behave identically.
+
+## Application Interfaces
+
+- **`app.py` (CLI)** – Run the program with sample arguments and ensure it
+  prints deterministic passwords and handles missing options gracefully.
+- **`gui.py`** – Manual testing: start the Tkinter interface, generate passwords
+  and seeds, and confirm clipboard or display behaviour.
+
+## Running the Test Suite
+
+Execute all automated tests with:
+
+```bash
+pytest -q
+```
+
+Consider extending coverage with edge cases such as empty inputs, network
+failures, and missing optional dependencies.


### PR DESCRIPTION
## Summary
- allow using python-nostr to sign and encrypt backups when available
- document optional nostr dependency in requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba9fc857d483339a4f13ec7328286b