### PR TITLE
Align Python Nostr nonce events with web protocol

### DIFF
--- a/python/tests/test_nostr_utils.py
+++ b/python/tests/test_nostr_utils.py
@@ -74,6 +74,10 @@ def test_backup_and_load_nonces(tmp_path, monkeypatch):
     # Store the nonces snapshot (publishing to relays is best-effort)
     backup_nonces_to_nostr(key, nonces, relay_urls=[], debug=True)
 
+    # Verify the event uses the standard backup tag
+    stored = json.loads(temp_file.read_text())[-1]
+    assert ["t", nu.BACKUP_TAG] in stored["tags"]
+
     # Ensure they can be loaded back
     loaded = load_nonces(key, relay_urls=[], debug=True)
     assert loaded == nonces


### PR DESCRIPTION
## Summary
- Publish nonce snapshots under the standard `nostr-pwd-backup` tag
- Parse `users` structure from backup events for nonce restoration
- Ensure tests confirm the shared tag between Python and browser implementations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbcd6600ac83338613e7ee2b933e29