### PR TITLE
Use single backup.json for Nostr backups

### DIFF
--- a/python/password_manager/nostr_utils.py
+++ b/python/password_manager/nostr_utils.py
@@ -60,7 +60,9 @@ except Exception:  # pragma: no cover
 logger = logging.getLogger(__name__)
 
 # Local JSON file used for unit tests and offline storage
-BACKUP_FILE = Path("backups.json")
+# The project intentionally avoids creating separate cache files and only
+# persists backup events to this single JSON file.
+BACKUP_FILE = Path("backup.json")
 
 # Tags used to classify different backup event types
 BACKUP_TAG = "nostr-pwd-backup"

--- a/python/tests/test_nostr_utils.py
+++ b/python/tests/test_nostr_utils.py
@@ -12,7 +12,7 @@ import time
 
 
 def test_backup_and_restore(tmp_path, monkeypatch):
-    temp_file = tmp_path / "backups.json"
+    temp_file = tmp_path / "backup.json"
     monkeypatch.setattr("password_manager.nostr_utils.BACKUP_FILE", temp_file)
     monkeypatch.setattr("password_manager.nostr_utils._SESSION_EVENTS", {})
 
@@ -33,7 +33,7 @@ def test_backup_and_restore(tmp_path, monkeypatch):
 
 def test_debug_logging(tmp_path, monkeypatch, capsys):
     """Debug logging should emit messages to the terminal when enabled."""
-    temp_file = tmp_path / "backups.json"
+    temp_file = tmp_path / "backup.json"
     monkeypatch.setattr("password_manager.nostr_utils.BACKUP_FILE", temp_file)
     monkeypatch.setattr("password_manager.nostr_utils._SESSION_EVENTS", {})
 
@@ -52,7 +52,7 @@ def test_debug_logging(tmp_path, monkeypatch, capsys):
 
 
 def test_restore_history(tmp_path, monkeypatch):
-    temp_file = tmp_path / "backups.json"
+    temp_file = tmp_path / "backup.json"
     monkeypatch.setattr("password_manager.nostr_utils.BACKUP_FILE", temp_file)
     monkeypatch.setattr("password_manager.nostr_utils._SESSION_EVENTS", {})
     key = "deadbeef"
@@ -64,7 +64,7 @@ def test_restore_history(tmp_path, monkeypatch):
 
 
 def test_backup_and_load_nonces(tmp_path, monkeypatch):
-    temp_file = tmp_path / "backups.json"
+    temp_file = tmp_path / "backup.json"
     monkeypatch.setattr("password_manager.nostr_utils.BACKUP_FILE", temp_file)
     monkeypatch.setattr("password_manager.nostr_utils._SESSION_EVENTS", {})
 
@@ -80,7 +80,7 @@ def test_backup_and_load_nonces(tmp_path, monkeypatch):
     
 
 def test_mock_relay_backup_and_restore(tmp_path, monkeypatch, capsys):
-    temp_file = tmp_path / "backups.json"
+    temp_file = tmp_path / "backup.json"
     monkeypatch.setattr("password_manager.nostr_utils.BACKUP_FILE", temp_file)
     monkeypatch.setattr("password_manager.nostr_utils._SESSION_EVENTS", {})
 
@@ -118,7 +118,7 @@ def test_mock_relay_backup_and_restore(tmp_path, monkeypatch, capsys):
 
 
 def test_mock_relay_history(tmp_path, monkeypatch):
-    temp_file = tmp_path / "backups.json"
+    temp_file = tmp_path / "backup.json"
     monkeypatch.setattr("password_manager.nostr_utils.BACKUP_FILE", temp_file)
     monkeypatch.setattr("password_manager.nostr_utils._SESSION_EVENTS", {})
 
@@ -153,7 +153,7 @@ def test_mock_relay_history(tmp_path, monkeypatch):
 
 
 def test_connection_logging_success(tmp_path, monkeypatch, caplog):
-    temp_file = tmp_path / "backups.json"
+    temp_file = tmp_path / "backup.json"
     monkeypatch.setattr("password_manager.nostr_utils.BACKUP_FILE", temp_file)
     monkeypatch.setattr("password_manager.nostr_utils._SESSION_EVENTS", {})
 
@@ -186,7 +186,7 @@ def test_connection_logging_success(tmp_path, monkeypatch, caplog):
 
 
 def test_connection_logging_failure(tmp_path, monkeypatch, caplog):
-    temp_file = tmp_path / "backups.json"
+    temp_file = tmp_path / "backup.json"
     monkeypatch.setattr("password_manager.nostr_utils.BACKUP_FILE", temp_file)
     monkeypatch.setattr("password_manager.nostr_utils._SESSION_EVENTS", {})
 


### PR DESCRIPTION
## Summary
- Ensure Nostr backups persist only to `backup.json`
- Update tests to reference `backup.json`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbcd3b55b083338fce41ddd52987a0